### PR TITLE
Repro wrong line numbers in stack trace

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,1 +1,9 @@
-console.log('Some .ts code reproducing a bug');
+function a() {}
+
+function b() {}
+
+function f() {
+  throw new Error("e");
+}
+
+f();


### PR DESCRIPTION
The stack trace should point towards line 6. However, it points to line 4 instead.