### PR TITLE
Reproduce wrong line numbers in stack traces under Node v20

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,1 +1,22 @@
-console.log('Some .ts code reproducing a bug');
+type Foo = {
+  foo: string,
+  bar: number,
+}
+
+function foofn () {
+  throw new Error('bar');
+}
+
+try {
+  foofn();
+}
+catch (err) {
+  const stack = (err as Error).stack || '';
+  if (/at foofn \(.*\/example\.ts:7:.*\)/.exec(stack)) {
+    console.log('OK, stack seems to have correct line numbers.');
+  }
+  else {
+    console.error('Grr, stack seems to have wrong line numbers.');
+    throw err;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "ts-node": "latest",
     "typescript": "latest"

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Install a specific version of node
-n lts
+n v20
 
 # Install package.json dependencies
 yarn
 
 # Run ts-node
-yarn ts-node ./example.ts
+node --loader ts-node/esm/transpile-only ./example.ts
 
 echo "Process exited with code: $?"
 echo

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Install a specific version of node
-n v20
+n v18.19.0
 
 # Install package.json dependencies
 yarn

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "includes": [
+    "example.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,1 @@
-{
-  "compilerOptions": {
-    "lib": [
-      "dom",
-      "esnext"
-    ]
-  },
-  "includes": [
-    "example.ts"
-  ]
-}
+{}


### PR DESCRIPTION
This reproduces the apparent bug (whether the root cause is in ts-node or in Node itself) that under Node v20.0.0 onwards (EDIT: and now also v18.19.0), line numbers are incorrect in stack traces thrown in TypeScript files, seeming to correspond to a module file stripped of its type declarations.

The CI runner failed to install Node v20 (when that was in run.sh, prior to https://github.com/TypeStrong/ts-node-repros/pull/34/commits/b551e879d527385c9ee32875c1cf3b8e3a5cd83b).

Once I changed that to v18.19.0, the CI output still reports a bunch of `cp: cannot remove '/usr/local/include/node/v8-locker.h': Permission denied`,  but it does seem to finish installing v18.19.0, and the CI output reports the problem I'm reproing (but also some Node internal error/warning):
```
Grr, stack seems to have wrong line numbers.
node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^

Error: bar
    at foofn (file:///home/runner/work/ts-node-repros/ts-node-repros/example.ts:2:11)
    at file:///home/runner/work/ts-node-repros/ts-node-repros/example.ts:5:5
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)

Node.js v18.19.0
Process exited with code: 1
```

(The CI job still reports green, which is a little misleading, but maybe that's the convention in this repo?)

If you change the Node version to v18.8.2 or earlier, the test passes, i.e. the line number will be correct.